### PR TITLE
Set AssignPublicIp to ENABLED

### DIFF
--- a/templates/container.template.yaml
+++ b/templates/container.template.yaml
@@ -355,7 +355,7 @@ Resources:
       LaunchType: FARGATE
       NetworkConfiguration:
         AwsvpcConfiguration:
-          AssignPublicIp: DISABLED
+          AssignPublicIp: ENABLED
           Subnets: !If 
             - 3AZDeployment
             - - !Ref PrivateSubnet1AID


### PR DESCRIPTION
Setting AssignPublicIp to ENABLED to allow users flexibility to use the quickstart with or without a NAT gateway. This edge case was highlighted by a client who did not want to use NAT gateway and private subnets.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
